### PR TITLE
Workaround for DelayedConfirmationView XML bug

### DIFF
--- a/wear/src/main/java/com/livefront/android_wear_demo/activity/DelayedConfirmationViewActivity.java
+++ b/wear/src/main/java/com/livefront/android_wear_demo/activity/DelayedConfirmationViewActivity.java
@@ -39,6 +39,11 @@ public class DelayedConfirmationViewActivity extends Activity implements
         mDelayedView = (DelayedConfirmationView)
                 findViewById(R.id.delayed_confirm);
 
+        // Programmatically hide due to visibility bug when setting value in XML. See the following
+        // issue for more details:
+        // https://code.google.com/p/android/issues/detail?id=90142
+        mDelayedView.setVisibility(View.GONE);
+
         // Set the timer to 2 seconds
         mDelayedView.setTotalTimeMs(2000);
 

--- a/wear/src/main/res/layout/activity_delayed_confirmation_view.xml
+++ b/wear/src/main/res/layout/activity_delayed_confirmation_view.xml
@@ -27,7 +27,6 @@
         android:layout_width="@dimen/delayed_confirmation_size"
         android:layout_height="@dimen/delayed_confirmation_size"
         android:layout_gravity="center"
-        android:visibility="gone"
         android:src="@drawable/ic_full_cancel"
         app:layout_box="all"
         app:circle_color="@color/demo_blue"


### PR DESCRIPTION
This PR fixes a crash caused by a bug in `DelayedConfirmationView`/`CircledImageView` when setting the visibility to `GONE` in XML. See the following for details:

https://code.google.com/p/android/issues/detail?id=90142